### PR TITLE
configuring worker ip address during manager launch via command line

### DIFF
--- a/worker/serverless_gpu/SVGPUManager.cpp
+++ b/worker/serverless_gpu/SVGPUManager.cpp
@@ -50,7 +50,8 @@ ava_proto::WorkerAssignReply SVGPUManager::HandleRequest(const ava_proto::Worker
   child_monitor->detach();
   worker_monitor_map_.insert({port, child_monitor});
 
-  reply.worker_address().push_back("0.0.0.0:" + std::to_string(port));
+  std::string worker_addr = worker_ip + ":" + std::to_string(port);
+  reply.worker_address().push_back(worker_addr);
 
   return reply;
 }

--- a/worker/serverless_gpu/SVGPUManager.hpp
+++ b/worker/serverless_gpu/SVGPUManager.hpp
@@ -8,14 +8,16 @@ using ava_manager::ManagerServiceServerBase;
 
 class SVGPUManager : public ManagerServiceServerBase {
   public:
-  SVGPUManager(uint32_t port, uint32_t worker_port_base, std::string worker_path, std::vector<std::string> &worker_argv,
+  SVGPUManager(uint32_t port, uint32_t worker_port_base, std::string worker_address, std::string worker_path, std::vector<std::string> &worker_argv,
             std::vector<std::string> &worker_env, uint16_t ngpus, uint16_t gpu_offset)
     : ManagerServiceServerBase(port, worker_port_base, worker_path, worker_argv, worker_env) {
       // TODO: choose scheduler somehow
       scheduler = new RoundRobin(ngpus, gpu_offset);
+      worker_ip.assign(worker_address);
     };
 
   BaseScheduler* scheduler;
+  std::string worker_ip;
 
   ava_proto::WorkerAssignReply HandleRequest(const ava_proto::WorkerAssignRequest &request) override;
 };

--- a/worker/serverless_gpu/manager.cpp
+++ b/worker/serverless_gpu/manager.cpp
@@ -5,6 +5,7 @@
 
 // arguments to this manager
 ABSL_FLAG(uint32_t, manager_port, 3333, "(OPTIONAL) Specify manager port number");
+ABSL_FLAG(std::vector<std::string>, worker_address, "0.0.0.0", "(OPTIONAL) Specify addres for workers to connect to guestlib");
 ABSL_FLAG(uint32_t, worker_port_base, 4000, "(OPTIONAL) Specify base port number of API servers");
 ABSL_FLAG(std::vector<std::string>, worker_argv, {}, "(OPTIONAL) Specify process arguments passed to API servers");
 ABSL_FLAG(std::string, worker_path, "", "(REQUIRED) Specify API server binary path");
@@ -20,6 +21,7 @@ int main(int argc, const char *argv[]) {
   auto worker_env = absl::GetFlag(FLAGS_worker_env);
   SVGPUManager* manager = new SVGPUManager(absl::GetFlag(FLAGS_manager_port), 
                       absl::GetFlag(FLAGS_worker_port_base),
+                      absl::GetFlag(FLAGS_worker_address), 
                       absl::GetFlag(FLAGS_worker_path), 
                       worker_argv, worker_env,
                       absl::GetFlag(FLAGS_ngpus),

--- a/worker/serverless_gpu/manager.cpp
+++ b/worker/serverless_gpu/manager.cpp
@@ -5,7 +5,7 @@
 
 // arguments to this manager
 ABSL_FLAG(uint32_t, manager_port, 3333, "(OPTIONAL) Specify manager port number");
-ABSL_FLAG(std::vector<std::string>, worker_address, "0.0.0.0", "(OPTIONAL) Specify addres for workers to connect to guestlib");
+ABSL_FLAG(std::vector<std::string>, worker_address, "0.0.0.0", "(OPTIONAL) Specify address for workers to connect to guestlib");
 ABSL_FLAG(uint32_t, worker_port_base, 4000, "(OPTIONAL) Specify base port number of API servers");
 ABSL_FLAG(std::vector<std::string>, worker_argv, {}, "(OPTIONAL) Specify process arguments passed to API servers");
 ABSL_FLAG(std::string, worker_path, "", "(REQUIRED) Specify API server binary path");


### PR DESCRIPTION
One of the changes that allows remote applications to run with AvA. To configure, add an argument `--worker_address <ip>` when running the `SVGPUManager`. Also need to create an ava.conf file that ensures the manager address is also forwarded.
